### PR TITLE
- Modified test_ibmq_qobj to run on all devices that support qobj

### DIFF
--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -307,7 +307,7 @@ def execute(circuits, backend,
     """
     # pylint: disable=missing-param-doc, missing-type-doc
     if isinstance(backend, str):
-        warnings.warn('execute() no longer takes backend string names.'
+        warnings.warn('execute() no longer takes backend string names. '
                       'Please pass backend objects, obtained via'
                       'IBMQ.get_backend() or Aer.get_backend().', DeprecationWarning)
         try:

--- a/test/python/aer/test_extensions_simulator.py
+++ b/test/python/aer/test_extensions_simulator.py
@@ -12,6 +12,7 @@
 import unittest
 import qiskit
 import qiskit.extensions.simulator
+from qiskit import Aer
 from qiskit.tools.qi.qi import state_fidelity
 from qiskit.wrapper import execute
 from ..common import QiskitTestCase, requires_cpp_simulator
@@ -36,7 +37,7 @@ class TestExtensionsSimulator(QiskitTestCase):
         circuit.h(qr[1])
         circuit.load(1)
 
-        sim = 'statevector_simulator'
+        sim = Aer.get_backend('statevector_simulator')
         result = execute(circuit, sim).result()
         statevector = result.get_statevector()
         target = [0.70710678 + 0.j, 0.70710678 + 0.j, 0. + 0.j, 0. + 0.j]
@@ -56,7 +57,7 @@ class TestExtensionsSimulator(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
         circuit.h(qr[1])
 
-        sim = 'statevector_simulator'
+        sim = Aer.get_backend('statevector_simulator')
         result = execute(circuit, sim).result()
         snapshot = result.get_snapshot(slot='3')
         target = [0.70710678 + 0.j, 0. + 0.j, 0. + 0.j, 0.70710678 + 0.j]
@@ -82,7 +83,7 @@ class TestExtensionsSimulator(QiskitTestCase):
                 'id': {'p_pauli': [1.0, 0.0, 0.0]}
             }
         }
-        sim = 'qasm_simulator'
+        sim = Aer.get_backend('qasm_simulator')
         shots = 1000
         result = execute(circuit, sim, config=config, shots=shots).result()
         counts = result.get_counts()

--- a/test/python/aer/test_simulator_interfaces.py
+++ b/test/python/aer/test_simulator_interfaces.py
@@ -42,8 +42,10 @@ class TestCrossSimulation(QiskitTestCase):
             "cpp vs. py statevector has low fidelity{0:.2g}.".format(fidelity))
 
     @requires_qe_access
-    def test_qasm(self, qe_token, qe_url):
+    def test_qasm(self, qe_tokens, qe_urls):
         """counts from a GHZ state"""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.IBMQ.enable_account(qe_token, qe_url)
         qr = qiskit.QuantumRegister(3)
         cr = qiskit.ClassicalRegister(3)
@@ -94,8 +96,10 @@ class TestCrossSimulation(QiskitTestCase):
         self.assertGreater(fidelity, self._desired_fidelity)
 
     @requires_qe_access
-    def test_qasm_reset_measure(self, qe_token, qe_url):
+    def test_qasm_reset_measure(self, qe_tokens, qe_urls):
         """counts from a qasm program with measure and reset in the middle"""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.IBMQ.enable_account(qe_token, qe_url)
         qr = qiskit.QuantumRegister(3)
         cr = qiskit.ClassicalRegister(3)

--- a/test/python/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/python/ibmq/test_ibmq_qasm_simulator.py
@@ -10,6 +10,7 @@
 """Test IBMQ online qasm simulator.
 TODO: Must expand tests. Re-evaluate after Aer."""
 
+from unittest import skip
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import transpiler
 from qiskit import IBMQ
@@ -75,6 +76,9 @@ class TestIbmqQasmSimulator(QiskitTestCase):
         self.assertDictAlmostEqual(counts1, target1, threshold)
         self.assertDictAlmostEqual(counts2, target2, threshold)
 
+    # TODO: Investigate why this test is failing in master:
+    # https://github.com/Qiskit/qiskit-terra/issues/1016
+    @skip('Intermitent failure, see: https://github.com/Qiskit/qiskit-terra/issues/1016 ')
     @requires_qe_access
     def test_online_qasm_simulator_two_registers(self, qe_token, qe_url):
         """Test online_qasm_simulator_two_registers.

--- a/test/python/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/python/ibmq/test_ibmq_qasm_simulator.py
@@ -9,7 +9,6 @@
 
 """Test IBMQ online qasm simulator.
 TODO: Must expand tests. Re-evaluate after Aer."""
-import unittest
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import transpiler
@@ -76,7 +75,6 @@ class TestIbmqQasmSimulator(QiskitTestCase):
         self.assertDictAlmostEqual(counts1, target1, threshold)
         self.assertDictAlmostEqual(counts2, target2, threshold)
 
-    @unittest.skip('Skipping due to register ordering confusion.')
     @requires_qe_access
     def test_online_qasm_simulator_two_registers(self, qe_token, qe_url):
         """Test online_qasm_simulator_two_registers.

--- a/test/python/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/python/ibmq/test_ibmq_qasm_simulator.py
@@ -21,11 +21,13 @@ class TestIbmqQasmSimulator(QiskitTestCase):
     """Test IBM Q Qasm Simulator."""
 
     @requires_qe_access
-    def test_execute_one_circuit_simulator_online(self, qe_token, qe_url):
+    def test_execute_one_circuit_simulator_online(self, qe_tokens, qe_urls):
         """Test execute_one_circuit_simulator_online.
 
         If all correct should return correct counts.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
@@ -44,11 +46,13 @@ class TestIbmqQasmSimulator(QiskitTestCase):
         self.assertDictAlmostEqual(counts, target, threshold)
 
     @requires_qe_access
-    def test_execute_several_circuits_simulator_online(self, qe_token, qe_url):
+    def test_execute_several_circuits_simulator_online(self, qe_tokens, qe_urls):
         """Test execute_several_circuits_simulator_online.
 
         If all correct should return correct counts.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
@@ -80,11 +84,13 @@ class TestIbmqQasmSimulator(QiskitTestCase):
     # https://github.com/Qiskit/qiskit-terra/issues/1016
     @skip('Intermitent failure, see: https://github.com/Qiskit/qiskit-terra/issues/1016 ')
     @requires_qe_access
-    def test_online_qasm_simulator_two_registers(self, qe_token, qe_url):
+    def test_online_qasm_simulator_two_registers(self, qe_tokens, qe_urls):
         """Test online_qasm_simulator_two_registers.
 
         If all correct should return correct counts.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 

--- a/test/python/ibmq/test_ibmq_qobj.py
+++ b/test/python/ibmq/test_ibmq_qobj.py
@@ -11,35 +11,22 @@
 
 """IBMQ Remote Backend Qobj Tests"""
 
-import os
 import unittest
 from qiskit import (ClassicalRegister, QuantumCircuit, QuantumRegister, compile)
 
 from qiskit import IBMQ, Aer
 from qiskit.qasm import pi
-from ..common import JobTestCase
+from ..common import requires_qe_access, JobTestCase
 
 
-class TestIBMQQobj(JobTestCase):
-    """Qiskit backend qobj test. Compares remote simulator as
-       configured in environment variables 'IBMQ_QOBJ_DEVICE',
-       'IBMQ_TOKEN' and 'IBMQ_QOBJ_URL' against local simulator
-       'local_qasm_simulator' as ground truth.
-    """
+class TestBackendQobj(JobTestCase):
 
-    def setUp(self):
+    @requires_qe_access
+    def setUp(self, qe_token, qe_url):
         super().setUp()
-        self._testing_device = os.getenv('IBMQ_QOBJ_DEVICE', None)
-        self._qe_token = os.getenv('IBMQ_TOKEN', None)
-        self._qe_url = os.getenv('IBMQ_QOBJ_URL')
-
-        if not self._testing_device or not self._qe_token or not self._qe_url:
-            self.skipTest("No credentials or testing device available for "
-                          "testing Qobj capabilities.")
-
-        IBMQ.enable_account(self._qe_token, self._qe_url)
-        self._local_backend = Aer.get_backend('local_qasm_simulator')
-        self._remote_backend = IBMQ.get_backend(self._testing_device)
+        IBMQ.enable_account(qe_token, qe_url)
+        self._local_backend = Aer.get_backend('qasm_simulator_py')
+        self._remote_backend = IBMQ.get_backend('ibmq_qasm_simulator')
         self.log.info('Remote backend: %s', self._remote_backend.name())
         self.log.info('Local backend: %s', self._local_backend.name())
 

--- a/test/python/ibmq/test_ibmq_qobj.py
+++ b/test/python/ibmq/test_ibmq_qobj.py
@@ -36,10 +36,10 @@ def once_per_qobj_backend(test):
 
         for qe_token, qe_url in zip(qe_tokens, qe_urls):
             IBMQ.enable_account(qe_token, qe_url)
-            for backend in IBMQ.backends():
-                if backend.configuration()['allow_q_object']:
-                    with self.subTest(backend=backend):
-                        test(self, backend, *args, **kwargs)
+        for backend in IBMQ.backends():
+            if backend.configuration()['allow_q_object']:
+                with self.subTest(backend=backend):
+                    test(self, backend, *args, **kwargs)
     return _wrapper
 
 

--- a/test/python/ibmq/test_ibmqjob.py
+++ b/test/python/ibmq/test_ibmqjob.py
@@ -9,7 +9,6 @@
 
 """IBMQJob Test."""
 
-import os
 import time
 import unittest
 from concurrent import futures

--- a/test/python/ibmq/test_ibmqjob.py
+++ b/test/python/ibmq/test_ibmqjob.py
@@ -331,39 +331,6 @@ class TestIBMQJob(JobTestCase):
             job.submit()
 
 
-class TestQObjectBasedIBMQJob(JobTestCase):
-    """Test jobs supporting QObject."""
-
-    def setUp(self):
-        super().setUp()
-        self._testing_device = os.getenv('IBMQ_QOBJ_DEVICE', None)
-        self._qe_token = os.getenv('IBMQ_TOKEN', None)
-        self._qe_url = os.getenv('IBMQ_QOBJ_URL')
-        if not self._testing_device or not self._qe_token or not self._qe_url:
-            self.skipTest('No credentials or testing device available for '
-                          'testing Qobj capabilities.')
-
-        IBMQ.enable_account(self._qe_token, self._qe_url)
-        self._backend = IBMQ.get_backend(self._testing_device)
-
-        self._qc = _bell_circuit()
-
-    def test_qobject_enabled_job(self):
-        """Job should be an instance of IBMQJob."""
-        qobj = transpiler.compile(self._qc, self._backend)
-        job = self._backend.run(qobj)
-        self.assertIsInstance(job, IBMQJob)
-
-    def test_qobject_result(self):
-        """Jobs can be retrieved."""
-        qobj = transpiler.compile(self._qc, self._backend)
-        job = self._backend.run(qobj)
-        try:
-            job.result()
-        except JobError as err:
-            self.fail(err)
-
-
 def _bell_circuit():
     qr = QuantumRegister(2, 'q')
     cr = ClassicalRegister(2, 'c')

--- a/test/python/ibmq/test_registration.py
+++ b/test/python/ibmq/test_registration.py
@@ -149,8 +149,10 @@ class TestIBMQAccounts(QiskitTestCase):
             self.assertEqual(len(read_credentials_from_qiskitrc()), 0)
 
     @requires_qe_access
-    def test_pass_bad_proxy(self, qe_token, qe_url):
+    def test_pass_bad_proxy(self, qe_tokens, qe_urls):
         """Test proxy pass through."""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         failed = False
         try:
             qiskit.IBMQ.enable_account(qe_token, qe_url, proxies=PROXIES)

--- a/test/python/test_backend_name_resolution.py
+++ b/test/python/test_backend_name_resolution.py
@@ -43,9 +43,11 @@ class TestBackendNameResolution(QiskitTestCase):
                     self.assertEqual(Aer.backends(oldname)[0], real_backend)
 
     @requires_qe_access
-    def test_aliases(self, qe_token, qe_url):
+    def test_aliases(self, qe_tokens, qe_urls):
         """Test that display names of devices map the same backends as the
         regular names."""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         aliased_names = IBMQ.aliased_backend_names()
 

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -36,31 +36,37 @@ class TestBackends(QiskitTestCase):
         self.assertTrue(len(local) > 0)
 
     @requires_qe_access
-    def test_remote_backends_exist(self, qe_token, qe_url):
+    def test_remote_backends_exist(self, qe_tokens, qe_urls):
         """Test if there are remote backends.
 
         If all correct some should exists.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends()
         self.assertTrue(len(remotes) > 0)
 
     @requires_qe_access
-    def test_remote_backends_exist_real_device(self, qe_token, qe_url):
+    def test_remote_backends_exist_real_device(self, qe_tokens, qe_urls):
         """Test if there are remote backends that are devices.
 
         If all correct some should exists.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends(simulator=False)
         self.assertTrue(remotes)
 
     @requires_qe_access
-    def test_remote_backends_exist_simulator(self, qe_token, qe_url):
+    def test_remote_backends_exist_simulator(self, qe_tokens, qe_urls):
         """Test if there are remote backends that are simulators.
 
         If all correct some should exists.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends(simulator=True)
         self.assertTrue(remotes)
@@ -91,14 +97,15 @@ class TestBackends(QiskitTestCase):
         jsonschema.validate(status, schema)
 
     @requires_qe_access
-    def test_remote_backend_status(self, qe_token, qe_url):
+    def test_remote_backend_status(self, qe_tokens, qe_urls):
         """Test backend_status.
 
         If all correct should pass the validation.
         """
         # FIXME: reintroduce in 0.6
         self.skipTest('Skipping due to available vs operational')
-
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends()
         remotes = remove_backends_from_list(remotes)
@@ -127,11 +134,13 @@ class TestBackends(QiskitTestCase):
             jsonschema.validate(configuration, schema)
 
     @requires_qe_access
-    def test_remote_backend_configuration(self, qe_token, qe_url):
+    def test_remote_backend_configuration(self, qe_tokens, qe_urls):
         """Test backend configuration.
 
         If all correct should pass the validation.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends(simulator=False)
         for backend in remotes:
@@ -155,11 +164,13 @@ class TestBackends(QiskitTestCase):
             self.assertEqual(len(properties), 0)
 
     @requires_qe_access
-    def test_remote_backend_properties(self, qe_token, qe_url):
+    def test_remote_backend_properties(self, qe_tokens, qe_urls):
         """Test backend properties.
 
         If all correct should pass the validation.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends(simulator=False)
         for backend in remotes:

--- a/test/python/test_circuit.py
+++ b/test/python/test_circuit.py
@@ -10,6 +10,7 @@
 """Test Qiskit's QuantumCircuit class."""
 
 import qiskit.extensions.simulator
+from qiskit import Aer
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import execute
 from qiskit import QISKitError
@@ -104,7 +105,7 @@ class TestCircuitCombineExtend(QiskitTestCase):
         qc1.measure(qr[0], cr[0])
         qc2.measure(qr[1], cr[1])
         new_circuit = qc1 + qc2
-        backend = 'qasm_simulator'
+        backend = Aer.get_backend('qasm_simulator')
         shots = 1024
         result = execute(new_circuit, backend=backend, shots=shots, seed=78).result()
         counts = result.get_counts()
@@ -122,7 +123,7 @@ class TestCircuitCombineExtend(QiskitTestCase):
         qc2 = QuantumCircuit(qr, cr)
         qc2.measure(qr, cr)
         new_circuit = qc1 + qc2
-        backend = 'qasm_simulator'
+        backend = Aer.get_backend('qasm_simulator')
         shots = 1024
         result = execute(new_circuit, backend=backend, shots=shots, seed=78).result()
         counts = result.get_counts()
@@ -158,10 +159,9 @@ class TestCircuitCombineExtend(QiskitTestCase):
         qc2.snapshot(slot='1')
         qc2.measure(qr, cr)
         new_circuit = qc1 + qc2
-        backend = 'qasm_simulator_py'
+        backend = Aer.get_backend('qasm_simulator_py')
         shots = 1024
         result = execute(new_circuit, backend=backend, shots=shots, seed=78).result()
-
         snapshot_vectors = result.get_snapshot()
         fidelity = state_fidelity(snapshot_vectors[0], desired_vector)
         self.assertGreater(fidelity, 0.99)
@@ -182,7 +182,7 @@ class TestCircuitCombineExtend(QiskitTestCase):
         qc1.measure(qr[0], cr[0])
         qc2.measure(qr[1], cr[1])
         qc1 += qc2
-        backend = 'qasm_simulator'
+        backend = Aer.get_backend('qasm_simulator')
         shots = 1024
         result = execute(qc1, backend=backend, shots=shots, seed=78).result()
         counts = result.get_counts()
@@ -200,7 +200,7 @@ class TestCircuitCombineExtend(QiskitTestCase):
         qc2 = QuantumCircuit(qr, cr)
         qc2.measure(qr, cr)
         qc1 += qc2
-        backend = 'qasm_simulator'
+        backend = Aer.get_backend('qasm_simulator')
         shots = 1024
         result = execute(qc1, backend=backend, shots=shots, seed=78).result()
         counts = result.get_counts()
@@ -236,7 +236,7 @@ class TestCircuitCombineExtend(QiskitTestCase):
         qc2.snapshot(slot='1')
         qc2.measure(qr, cr)
         qc1 += qc2
-        backend = 'qasm_simulator_py'
+        backend = Aer.get_backend('qasm_simulator_py')
         shots = 1024
         result = execute(qc1, backend=backend, shots=shots, seed=78).result()
 

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -441,9 +441,9 @@ class TestCompiler(QiskitTestCase):
         bell.measure(qr[0], cr[0])
         bell.measure(qr[1], cr[1])
         shots = 2048
-        bell_qobj = compile(bell, backend='qasm_simulator',
+        bell_qobj = compile(bell, backend=backend,
                             shots=shots, seed=10)
-        ghz_qobj = compile(ghz, backend='qasm_simulator',
+        ghz_qobj = compile(ghz, backend=backend,
                            shots=shots, coupling_map=coupling_map,
                            seed=10)
         bell_result = backend.run(bell_qobj).result()
@@ -496,6 +496,7 @@ class TestCompiler(QiskitTestCase):
 
         Uses the mapper. Pass if results are correct.
         """
+        backend = qiskit.Aer.get_backend('qasm_simulator')
         coupling_map = [[0, 1], [0, 8], [1, 2], [1, 9], [2, 3], [2, 10],
                         [3, 4], [3, 11], [4, 5], [4, 12], [5, 6], [5, 13],
                         [6, 7], [6, 14], [7, 15], [8, 9], [9, 10], [10, 11],
@@ -520,13 +521,13 @@ class TestCompiler(QiskitTestCase):
             qc.measure(qr0[j], ans[j])
             qc.measure(qr1[j], ans[j+n])
         # First version: no mapping
-        result = execute(qc, backend='qasm_simulator',
+        result = execute(qc, backend=backend,
                          coupling_map=None, shots=1024,
                          seed=14).result()
         self.assertEqual(result.get_counts(qc),
                          {'010000': 1024})
         # Second version: map to coupling graph
-        result = execute(qc, backend='qasm_simulator',
+        result = execute(qc, backend=backend,
                          coupling_map=coupling_map, shots=1024,
                          seed=14).result()
         self.assertEqual(result.get_counts(qc),

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -160,11 +160,13 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(results, Result)
 
     @requires_qe_access
-    def test_compile_remote(self, qe_token, qe_url):
+    def test_compile_remote(self, qe_tokens, qe_urls):
         """Test Compiler remote.
 
         If all correct some should exists.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = least_busy(qiskit.IBMQ.backends())
 
@@ -181,11 +183,13 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(qobj, Qobj)
 
     @requires_qe_access
-    def test_compile_two_remote(self, qe_token, qe_url):
+    def test_compile_two_remote(self, qe_tokens, qe_urls):
         """Test Compiler remote on two circuits.
 
         If all correct some should exists.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = least_busy(qiskit.IBMQ.backends())
 
@@ -203,11 +207,13 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(qobj, Qobj)
 
     @requires_qe_access
-    def test_compile_run_remote(self, qe_token, qe_url):
+    def test_compile_run_remote(self, qe_tokens, qe_urls):
         """Test Compiler and run remote.
 
         If all correct some should exists.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = qiskit.IBMQ.get_backend(local=False, simulator=True)
 
@@ -223,11 +229,13 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(result, Result)
 
     @requires_qe_access
-    def test_compile_two_run_remote(self, qe_token, qe_url):
+    def test_compile_two_run_remote(self, qe_tokens, qe_urls):
         """Test Compiler and run two circuits.
 
         If all correct some should exists.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = qiskit.IBMQ.get_backend(local=False, simulator=True)
 
@@ -245,11 +253,13 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(result, Result)
 
     @requires_qe_access
-    def test_execute_remote(self, qe_token, qe_url):
+    def test_execute_remote(self, qe_tokens, qe_urls):
         """Test Execute remote.
 
         If all correct some should exists.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = qiskit.IBMQ.get_backend(local=False, simulator=True)
 
@@ -265,11 +275,13 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(results, Result)
 
     @requires_qe_access
-    def test_execute_two_remote(self, qe_token, qe_url):
+    def test_execute_two_remote(self, qe_tokens, qe_urls):
         """Test execute two remote.
 
         If all correct some should exists.
         """
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = qiskit.IBMQ.get_backend(local=False, simulator=True)
 

--- a/test/python/test_filter_backends.py
+++ b/test/python/test_filter_backends.py
@@ -16,8 +16,10 @@ class TestBackendFilters(QiskitTestCase):
     """QISKit Backend Filtering Tests."""
 
     @requires_qe_access
-    def test_filter_config_properties(self, qe_token, qe_url):
+    def test_filter_config_properties(self, qe_tokens, qe_urls):
         """Test filtering by configuration properties"""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         n_qubits = 20 if self.using_ibmq_credentials else 5
 
         IBMQ.enable_account(qe_token, qe_url)
@@ -25,8 +27,10 @@ class TestBackendFilters(QiskitTestCase):
         self.assertTrue(filtered_backends)
 
     @requires_qe_access
-    def test_filter_status_dict(self, qe_token, qe_url):
+    def test_filter_status_dict(self, qe_tokens, qe_urls):
         """Test filtering by dictionary of mixed status/configuration properties"""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         filtered_backends = IBMQ.backends(
             operational=True,  # from status
@@ -35,8 +39,10 @@ class TestBackendFilters(QiskitTestCase):
         self.assertTrue(filtered_backends)
 
     @requires_qe_access
-    def test_filter_config_callable(self, qe_token, qe_url):
+    def test_filter_config_callable(self, qe_tokens, qe_urls):
         """Test filtering by lambda function on configuration properties"""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         filtered_backends = IBMQ.backends(
             filters=lambda x: (not x.configuration()['simulator']
@@ -44,8 +50,10 @@ class TestBackendFilters(QiskitTestCase):
         self.assertTrue(filtered_backends)
 
     @requires_qe_access
-    def test_filter_least_busy(self, qe_token, qe_url):
+    def test_filter_least_busy(self, qe_tokens, qe_urls):
         """Test filtering by least busy function"""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         IBMQ.enable_account(qe_token, qe_url)
         backends = IBMQ.backends()
         filtered_backends = least_busy(backends)

--- a/test/python/test_reordering.py
+++ b/test/python/test_reordering.py
@@ -25,8 +25,10 @@ class TestBitReordering(QiskitTestCase):
     """
     @slow_test
     @requires_qe_access
-    def test_basic_reordering(self, qe_token, qe_url):
+    def test_basic_reordering(self, qe_tokens, qe_urls):
         """a simple reordering within a 2-qubit register"""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         sim, real = self._get_backends(qe_token, qe_url)
         if not sim or not real:
             raise unittest.SkipTest('no remote device available')
@@ -52,8 +54,10 @@ class TestBitReordering(QiskitTestCase):
 
     @slow_test
     @requires_qe_access
-    def test_multi_register_reordering(self, qe_token, qe_url):
+    def test_multi_register_reordering(self, qe_tokens, qe_urls):
         """a more complicated reordering across 3 registers of different sizes"""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         sim, real = self._get_backends(qe_token, qe_url)
         if not sim or real:
             raise unittest.SkipTest('no remote device available')

--- a/test/python/test_result.py
+++ b/test/python/test_result.py
@@ -39,8 +39,10 @@ class TestQiskitResult(QiskitTestCase):
         self.assertEqual(self._result1.circuit_statuses(), ['DONE'])
 
     @requires_qe_access
-    def test_ibmq_result_fields(self, qe_token, qe_url):
+    def test_ibmq_result_fields(self, qe_tokens, qe_urls):
         """Test components of a result from a remote simulator."""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.IBMQ.enable_account(qe_token, qe_url)
         remote_backend = qiskit.IBMQ.get_backend(local=False, simulator=True)
         remote_result = qiskit.execute(self._qc1, remote_backend).result()

--- a/test/python/test_wrapper.py
+++ b/test/python/test_wrapper.py
@@ -32,8 +32,10 @@ class TestWrapper(QiskitTestCase):
         self.circuit.measure(qr, cr)
 
     @requires_qe_access
-    def test_wrapper_register_ok(self, qe_token, qe_url):
+    def test_wrapper_register_ok(self, qe_tokens, qe_urls):
         """Test wrapper.register()."""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.wrapper.register(qe_token, qe_url)
         backends = qiskit.wrapper.available_backends()
         backends = remove_backends_from_list(backends)
@@ -41,8 +43,10 @@ class TestWrapper(QiskitTestCase):
         self.assertTrue(len(backends) > 0)
 
     @requires_qe_access
-    def test_backends_with_filter(self, qe_token, qe_url):
+    def test_backends_with_filter(self, qe_tokens, qe_urls):
         """Test wrapper.available_backends(filter=...)."""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.wrapper.register(qe_token, qe_url)
         backends = qiskit.wrapper.available_backends({'local': False,
                                                       'simulator': True})
@@ -56,8 +60,10 @@ class TestWrapper(QiskitTestCase):
         self.assertTrue(len(aer_backends) > 0)
 
     @requires_qe_access
-    def test_register_twice(self, qe_token, qe_url):
+    def test_register_twice(self, qe_tokens, qe_urls):
         """Test double registration of the same credentials."""
+        qe_token = qe_tokens[0]
+        qe_url = qe_urls[0]
         qiskit.wrapper.register(qe_token, qe_url)
         initial_providers = registered_providers()
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
- Added test decorator @once_per_qobj_backend that runs tests on all available backends that support qobj
    - This contains decorator requires_qe_access only once so VCR should work properly.
- Modified requires_qe_access so that it returns kwargs `qe_tokens` and `qe_urls` which contain all available tokens and urls.
- Modified others test to select only the first token and url.
- Removed TestQObjectBasedIBMQJob


### Details and comments


